### PR TITLE
feat: Docker CI/CD 워크플로우 추가

### DIFF
--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -1,0 +1,45 @@
+name: Docker Image CI/CD
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*' # Trigger on tags like v1.0.0, v1.0.1, etc.
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: harucare
+  REPOSITORY_OWNER: henrifola
+  REPOSITORY_NAME: GenAi-Healthcare-Project
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY_OWNER }}/${{ env.REPOSITORY_NAME }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY_OWNER }}/${{ env.REPOSITORY_NAME }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY_OWNER }}/${{ env.REPOSITORY_NAME }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}


### PR DESCRIPTION
1. github action 으로 자동으로 docker image 를 빌드합니다
2. github container registry(ghcr) 에 이미지를 자동 배포합니다.

github action 과 container registry 의 가격 정책을 확인해보고 진행하면 좋을것 같습니다

만약 불가능할것 같다면 branch 를 제거해주세요